### PR TITLE
URLs including non-ASCII are escaped with UTF 8.

### DIFF
--- a/Otaku Time/Controls/SingleLoadedAnime.cs
+++ b/Otaku Time/Controls/SingleLoadedAnime.cs
@@ -40,6 +40,10 @@ namespace Otaku_Time
             EpisodesFlowPanel.Controls.Clear();
             AnimeSynopsis.Text = CleanSynopsis(AnimeSynopsis.Text);
 
+            var splitData = AnimeUrl.Split('/');
+            splitData[splitData.Length - 1] = System.Web.HttpUtility.UrlEncode(splitData.Last(), System.Text.Encoding.UTF8);
+            AnimeUrl = string.Join("/", splitData);
+
             _phantomObject.Navigate().GoToUrl(AnimeUrl);
             if (needSynopsis)
             {


### PR DESCRIPTION
example supported for special url. for #4 issue.
I do not mind cancellation bacause this is my example.
I would appreciate it if you could refer.